### PR TITLE
Fix RSP base definitions

### DIFF
--- a/libn64/rcp/rsp.h
+++ b/libn64/rcp/rsp.h
@@ -14,22 +14,22 @@
 #include <mmio.h>
 
 #define RSP_MEM_BASE     0xA4000000 // $04000000..$04000FFF SP MEM Base Register
-#define RSP_DMEM         IO_32(SP_MEM_BASE,0x0000) // $04000000..$04000FFF SP: RSP DMEM (4096 Bytes)
-#define RSP_IMEM         IO_32(SP_MEM_BASE,0x1000) // $04001000..$04001FFF SP: RSP IMEM (4096 Bytes)
+#define RSP_DMEM         IO_32(RSP_MEM_BASE,0x0000) // $04000000..$04000FFF SP: RSP DMEM (4096 Bytes)
+#define RSP_IMEM         IO_32(RSP_MEM_BASE,0x1000) // $04001000..$04001FFF SP: RSP IMEM (4096 Bytes)
 
 #define RSP_BASE         0xA4040000 // $04040000..$0404001F SP Base Register
-#define RSP_MEM_ADDR     IO_32(SP_BASE,0x00) // $04040000..$04040003 SP: Master, SP Memory Address Register
-#define RSP_DRAM_ADDR    IO_32(SP_BASE,0x04) // $04040004..$04040007 SP: Slave, SP DRAM DMA Address Register
-#define RSP_RD_LEN       IO_32(SP_BASE,0x08) // $04040008..$0404000B SP: Read DMA Length Register
-#define RSP_WR_LEN       IO_32(SP_BASE,0x0C) // $0404000C..$0404000F SP: Write DMA Length Register
-#define RSP_STATUS       IO_32(SP_BASE,0x10) // $04040010..$04040013 SP: Status Register
-#define RSP_DMA_FULL     IO_32(SP_BASE,0x14) // $04040014..$04040017 SP: DMA Full Register
-#define RSP_DMA_BUSY     IO_32(SP_BASE,0x18) // $04040018..$0404001B SP: DMA Busy Register
-#define RSP_SEMAPHORE    IO_32(SP_BASE,0x1C) // $0404001C..$0404001F SP: Semaphore Register
+#define RSP_MEM_ADDR     IO_32(RSP_BASE,0x00) // $04040000..$04040003 SP: Master, SP Memory Address Register
+#define RSP_DRAM_ADDR    IO_32(RSP_BASE,0x04) // $04040004..$04040007 SP: Slave, SP DRAM DMA Address Register
+#define RSP_RD_LEN       IO_32(RSP_BASE,0x08) // $04040008..$0404000B SP: Read DMA Length Register
+#define RSP_WR_LEN       IO_32(RSP_BASE,0x0C) // $0404000C..$0404000F SP: Write DMA Length Register
+#define RSP_STATUS       IO_32(RSP_BASE,0x10) // $04040010..$04040013 SP: Status Register
+#define RSP_DMA_FULL     IO_32(RSP_BASE,0x14) // $04040014..$04040017 SP: DMA Full Register
+#define RSP_DMA_BUSY     IO_32(RSP_BASE,0x18) // $04040018..$0404001B SP: DMA Busy Register
+#define RSP_SEMAPHORE    IO_32(RSP_BASE,0x1C) // $0404001C..$0404001F SP: Semaphore Register
 
 #define RSP_PC_BASE      0xA4080000 // $04080000..$04080007 SP PC Base Register
-#define RSP_PC           IO_32(SP_PC_BASE,0x00) // $04080000..$04080003 SP: PC Register
-#define RSP_IBIST_REG    IO_32(SP_PC_BASE,0x04) // $04080004..$04080007 SP: IMEM BIST Register
+#define RSP_PC           IO_32(RSP_PC_BASE,0x00) // $04080000..$04080003 SP: PC Register
+#define RSP_IBIST_REG    IO_32(RSP_PC_BASE,0x04) // $04080004..$04080007 SP: IMEM BIST Register
 
 #define RSP_STATUS_CLEAR_HALT               (1 <<  0)
 #define RSP_STATUS_SET_HALT                 (1 <<  1)


### PR DESCRIPTION
Resolves the `SP`->`RSP` definition inconsistency in the `rsp.h` header.
