### PR TITLE
Mac OS X support for Unix toolchain setup script

### DIFF
--- a/rspasm/Makefile
+++ b/rspasm/Makefile
@@ -22,6 +22,10 @@ FLEX = flex
 CFLAGS = -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -I. -D_POSIX_C_SOURCE
 OPTFLAGS = -O2
 
+ifneq ($(UNAME_S),Darwin)
+CFLAGS += -static
+endif
+
 CFILES = \
 	emitter.c \
 	lexer.c \
@@ -38,7 +42,7 @@ all: rspasm
 
 rspasm: $(OBJFILES)
 	@echo $(call FIXPATH,"Linking: rspasm/$@")
-	@$(CC) -static $(CFLAGS) $(OPTFLAGS) $^ $(RSPASM_LIBS) -o $@
+	@$(CC) $(CFLAGS) $(OPTFLAGS) $^ $(RSPASM_LIBS) -o $@
 
 parser.c: parser.y
 	@echo $(call FIXPATH,"Generating: rspasm/$@")


### PR DESCRIPTION
It turns out that the Linux toolchain script works on Mac OS X with some very minor tweaks:
- [Static linking of binaries is not supported](https://developer.apple.com/library/mac/qa/qa1118/_index.html)
- [The GCC prerequisite libraries GMP, MPFR and MPC are not part of OS X and must be downloaded. In order to provide additional support for Unixes with old/missing versions of these packages, these prerequisites can simply always be downloaded and built along with GCC.](https://gcc.gnu.org/wiki/InstallingGCC)
