### PR TITLE
Define some COP0 constants; refactor `cubedemo` interrupt handling

### DIFF
--- a/cubedemo/src/graphics.S
+++ b/cubedemo/src/graphics.S
@@ -8,6 +8,12 @@
 # 'LICENSE', which is part of this source code package.
 #
 
+#include "vr4300/cp0.h"
+#include "rcp/mi.h"
+#include "rcp/vi.h"
+
+#define MI_INTR_VI 0x08
+
 .file "src/graphics.S"
 .section .rodata
 .align 3
@@ -20,38 +26,78 @@ rsp_ucode:
 .size rsp_ucode,.-rsp_ucode
 
 #
-# Invoked on a VI interrupt.
+# Invoked on interrupt.
 #
 .text
+.set noreorder
 .global __interrupt_handler
 .type __interrupt_handler, @function
 __interrupt_handler:
 
+  # TODO Preserve registers
+
+  mfc0 $k0, COP0_CAUSE
+  andi $k1, $k0, COP0_CAUSE_EXCEPTION
+  beqz $k1, __interrupt_handler_maybe_pre_nmi_interrupt
+  nop
+
+  # TODO Critical Exception Failure
+  nop
+
+__interrupt_handler_maybe_pre_nmi_interrupt:
+  andi $k1, $k0, COP0_CAUSE_PRENMI
+  beqz $k1, __interrupt_handler_maybe_count_interrupt
+  nop
+
+  # TODO Pre-Reset Interrupt Handler
+  nop
+
+__interrupt_handler_maybe_count_interrupt:
+  andi $k1, $k0, COP0_CAUSE_TIMER
+  beqzl $k1, __interrupt_handler_maybe_vi_interrupt
+  mtc0 $0, COP0_COMPARE
+
+  # TODO Timer Interrupt Handler
+  nop
+
+__interrupt_handler_maybe_vi_interrupt:
+  # Determine interrupt reason.
+  #
+  # If MI status VI interrupt bit is set, swap the framebuffer.
+  # If MI status VI interrupt bit is not set, just clear the exception.
+  li $k0, MI_BASE
+  lw $k1, MI_INTR($k0)
+  andi $k1, $k1, MI_INTR_VI
+  beqz $k1, __interrupt_handler_finish
+  nop
+
+__interrupt_handler_determine_framebuffer:
   # Set VI origin to the second frame.
   #
   # If VI_ORIGIN_REG is 0x0010 0000, set it to 0x0020 0000.
   # If VI_ORIGIN_REG is 0x0020 0000, set it to 0x0010 0000.
-  lui $k0, 0xA440
-  lw $k1, 0x0004($k0)
+  li $k0, VI_BASE
+  lw $k1, VI_ORIGIN($k0)
   srl $k1, $k1, 0x15
 
-.set noreorder
-  beql $k1, $0, __interrupt_handler_continue
+  beql $k1, $0, __interrupt_handler_set_framebuffer
   ori $k1, $0, 0x2
-.set reorder
 
-__interrupt_handler_continue:
+__interrupt_handler_set_framebuffer:
   sll $k1, $k1, 0x14
-  sw $k1, 0x0004($k0)
+  sw $k1, VI_ORIGIN($k0)
 
   # Clear the pending VI interrupt.
-  sw $0, 0x0010($k0)
+  sw $0, VI_V_CURRENT_LINE($k0)
 
+__interrupt_handler_finish:
   # Clear exception level and return.
-  mfc0 $k0, $12
-  xor $k0, $k0, 0x2
-  mtc0 $k0, $12
+  mfc0 $k0, COP0_STATUS
+  xor $k0, $k0, COP0_STATUS_EXCEPTION
+  mtc0 $k0, COP0_STATUS
   eret
+
+.set reorder
 
 .size __interrupt_handler,.-__interrupt_handler
 

--- a/libn64/include/time.h
+++ b/libn64/include/time.h
@@ -11,6 +11,8 @@
 #ifndef LIBN64_TIME_H
 #define LIBN64_TIME_H
 
+#include "vr4300/cp0.h"
+
 typedef long time_t;
 typedef unsigned long clock_t;
 
@@ -29,7 +31,7 @@ struct timeval {
 static inline clock_t clock(void) {
     clock_t count;
     __asm__ __volatile__(
-        "mfc0 %0,$9"
+        "mfc0 %0, "COP0_COUNT
         :"=r" (count)::);
     return count;
 }

--- a/libn64/vr4300/cp0.h
+++ b/libn64/vr4300/cp0.h
@@ -11,6 +11,25 @@
 #ifndef LIBN64_VR4300_CP0_H
 #define LIBN64_VR4300_CP0_H
 
+#define COP0_STATUS_EXCEPTION 0x2
+#define COP0_CAUSE_EXCEPTION 0x00FF
+#define COP0_CAUSE_PRENMI 0x1000
+#define COP0_CAUSE_TIMER 0x8000
+
+#ifdef __LANGUAGE_ASSEMBLY
+
+#define COP0_COUNT $9
+#define COP0_COMPARE $11
+#define COP0_STATUS $12
+#define COP0_CAUSE $13
+
+#else
+
+#define COP0_COUNT "$9"
+#define COP0_COMPARE "$11"
+#define COP0_STATUS "$12"
+#define COP0_CAUSE "$13"
+
 #include <stdint.h>
 
 //
@@ -20,10 +39,10 @@ static inline void vr4300_cp0_disable_interrupts(void) {
   uint32_t status;
 
   __asm__ __volatile__(
-    "mfc0 %[status], $12\n\t"
+    "mfc0 %[status], "COP0_STATUS"\n\t"
     "srl %[status], %[status], 0x1\n\t"
     "sll %[status], %[status], 0x1\n\t"
-    "mtc0 %[status], $12\n\t"
+    "mtc0 %[status], "COP0_STATUS"\n\t"
 
     : [status] "=r"(status)
   );
@@ -36,9 +55,9 @@ static inline void vr4300_cp0_enable_interrupts(void) {
   uint32_t status;
 
   __asm__ __volatile__(
-    "mfc0 %[status], $12\n\t"
+    "mfc0 %[status], "COP0_STATUS"\n\t"
     "ori %[status], %[status], 0x1\n\t"
-    "mtc0 %[status], $12\n\t"
+    "mtc0 %[status], "COP0_STATUS"\n\t"
 
     : [status] "=r"(status)
   );
@@ -50,7 +69,7 @@ static inline void vr4300_cp0_enable_interrupts(void) {
 //   3C1A____  lui  k0,     0x____
 //   375A____  ori  k0, k0, 0x____
 //   03400008  jr   k0
-//   401A6800  mfc0 k0, $13
+//   401A6800  mfc0 k0, $13 (COP0_CAUSE)
 //
 static inline void vr4300_install_interrupt_handler(uintptr_t addr) {
   *(volatile uint32_t *) 0xA0000180 = (0x3C1A0000) | (addr >> 16);
@@ -64,3 +83,4 @@ static inline void vr4300_install_interrupt_handler(uintptr_t addr) {
 
 #endif
 
+#endif


### PR DESCRIPTION
- Utilize constants and labels to improve readability
- Prevent GCC from reordering the handler instructions and screwing it up
- Restrict framebuffer swap to VI interrupts (prevents tearing)
- Stub in other useful interrupt hooks for later :)
